### PR TITLE
Add option to conserve column density

### DIFF
--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -2,19 +2,17 @@
 
 ## Quickstart
 
-Make an atmospheric profile using *Joseki*'s 
-[make](reference.md#src.joseki.core.make) method.
-Use its `identifier` parameter to specify the atmospheric profile.
- 
-!!! example "Example"
+The main interface of *Joseki* is its [make](reference.md#src.joseki.core.make) 
+method.
+This method creates the atmospheric profile corresponding to a given identifier.
+For example, make the so-called *AFGL US Standard* atmospheric profile from 
+[Anderson et al (1986)](bibliography.md#Anderson+1986) with:
 
-    Make the *AFGL (1986) US Standard* profile with:
+```python
+import joseki
 
-    ```python
-    import joseki
-
-    ds = joseki.make(identifier="afgl_1986-us_standard")
-    ```
+ds = joseki.make(identifier="afgl_1986-us_standard")
+```
 
 
 Display the available identifiers with:
@@ -26,11 +24,24 @@ list(factory.registry.keys())
 ```
 
 Use the [`to_dataset`](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.to_netcdf.html)
-method to save the dataset to the disk as a NetCDF file:
+method to save the dataset to the disk as a 
+[netCDF](https://www.unidata.ucar.edu/software/netcdf/) file:
 
 ```python
-ds.to_netcdf("my_data_set.nc")
+ds.to_netcdf("my_dataset.nc")
 ```
+
+For other formats, refer to the 
+[xarray IO documentation](https://docs.xarray.dev/en/stable/user-guide/io.html).
+
+??? example "Saving to CSV file"
+
+    ```python
+    ds.to_dataframe().to_csv("my_dataset.csv")
+    ```
+
+    Note that one drawback of saving to a CSV file in the above manner is that
+    the information on the quantity units is lost.
 
 Open the dataset again using 
 [`xarray.open_dataset`](https://docs.xarray.dev/en/stable/generated/xarray.open_dataset.html):
@@ -38,11 +49,48 @@ Open the dataset again using
 ```python
 import xarray as xr
 
-ds = xr.open_dataset("my_data_set.nc")
+ds = xr.open_dataset("my_dataset.nc")
 ```
 
 The datasets format is described [here](explanation.md#data-set-format).
 
+## Altitude grid
+
+You can specify the altitude grid for your atmospheric profile. If the source
+atmospheric profile is based on tabulated data, it is going to be interpolated
+on the specified altitude grid.
+
+??? example "Example"
+
+    ```python
+    import numpy as np
+
+    from joseki.units import ureg
+
+
+    ds = joseki.make(
+        identifier="afgl_1986-us_standard",
+        z=np.linspace(0, 100, 51) * ureg.km,
+    )
+    ```
+
+During interpolation, the column number densities associated to the different
+atmospheric constituents are likely going to be changed.
+In the example above, the ozone column number density is increased to 
+346.60 Dobson units compared to the atmospheric profile with the original
+altitude grid, which has an ozone column number density of 345.75 Dobson units.
+To ensure column densities are conserved during interpolation, set the 
+`conserve_column` parameter to `True`.
+
+??? example "Example"
+
+    ```python
+    ds = joseki.make(
+        identifier="afgl_1986-us_standard",
+        z=np.linspace(0, 100, 51) * ureg.km,
+        conserve_column=True,
+    )
+    ```
 ## Cells representation
 
 To make an atmospheric profile where data variables are given in altitude cells
@@ -60,10 +108,18 @@ The resulting dataset has a coordinate variable `z` that corresponds to
 the altitude cells center and a data variable `z_bounds` that indicate the
 altitude bounds of each altitude cell, i.e. atmospheric layer.
 
+Note that moving a profile from the nodes-representation to the 
+cells-representation is achieved by interpolating the nodes-represented profile.
+As a result, column densities are likely to be different in the 
+cells-represented profile.
+
+Similarly to [when specifying the altitude grid](#altitude-grid), you can 
+ensure that column densities are conserved with the `conserve_column` parameter.
+
 ## Advanced options
 
 The collection of atmospheric profiles defined by
-`Anderson1986AtmosphericConstituentProfiles` includes volume mixing
+[Anderson et al (1986)](bibliography.md#Anderson+1986) includes volume mixing
 ratio data for 28 molecules, where molecules 8-28 are described as *additional*.
 By default, these additional molecules are included in the atmospheric profile.
 To discard these additional molecules, set the `additional_molecules`

--- a/src/joseki/core.py
+++ b/src/joseki/core.py
@@ -16,10 +16,11 @@ def make(
     z: t.Optional[pint.Quantity] = None,
     interp_method: t.Optional[t.Mapping[str, str]] = DEFAULT_METHOD,
     represent_in_cells: bool = False,
+    conserve_column: bool = False,
     **kwargs: t.Any,
 ) -> xr.Dataset:
     """
-    Create a profile.
+    Create a profile with the specified identifier.
 
     Args:
         identifier: Profile identifier.
@@ -28,16 +29,18 @@ def make(
         represent_in_cells: If `True`, compute the altitude layer centers and 
             interpolate the profile on the layer centers, and return the 
             interpolated profile.
+        conserve_column: If `True`, ensure that column densities are conserved
+            during interpolation.
         kwargs: Additional keyword arguments passed to the profile constructor.
     
     Returns:
         Profile as xarray.Dataset.
     """
     logger.info("Creating profile %s", identifier)
-    logger.debug("profile: %s", identifier)
     logger.debug("z: %s", z)
     logger.debug("interp_method: %s", interp_method)
     logger.debug("represent_in_cells: %s", represent_in_cells)
+    logger.debug("conserve_column: %s", conserve_column)
     logger.debug("kwargs: %s", kwargs)
 
     profile = factory.create(identifier)
@@ -46,11 +49,15 @@ def make(
     ds = profile.to_dataset(
         z=z,
         interp_method=interp_method,
+        conserve_column=conserve_column,
         **kwargs,
     )
 
     if represent_in_cells:
-        logger.debug("representing profile in cells")
-        ds = represent_profile_in_cells(ds, method=interp_method)
+        ds = represent_profile_in_cells(
+            ds,
+            method=interp_method,
+            conserve_column=conserve_column,
+        )
     
     return ds

--- a/src/joseki/profiles/afgl_1986.py
+++ b/src/joseki/profiles/afgl_1986.py
@@ -213,6 +213,7 @@ def to_dataset(
     identifier: Identifier,
     z: t.Optional[pint.Quantity] = None,
     interp_method: t.Mapping[str, str] = None,
+    conserve_column: bool = False,
     **kwargs: t.Any,
 ) -> xr.Dataset:
     """
@@ -227,11 +228,11 @@ def to_dataset(
             If ``None``, return the original dataset
             Else, interpolate the dataset to the new level altitudes.
             Default is ``None``.
-        interp_method: dict, optional
-            Interpolation method for each data variable.
-            Default is ``None``.
-        kwargs: str
-            Additional arguments passed to 
+        interp_method: Interpolation method for each data variable. Default is 
+            ``None``.
+        conserve_column: If `True`, ensure that column densities are conserved
+            during interpolation.
+        kwargs: Additional arguments passed to 
             [`get_dataset`](reference.md#src.joseki.profiles.afgl_1986.get_dataset).
 
     Returns:
@@ -259,7 +260,12 @@ def to_dataset(
     # Interpolate if necessary
     if z is not None:
         method = interp_method if interp_method is not None else DEFAULT_METHOD
-        ds = interp(ds=ds, z_new=z, method=method)
+        ds = interp(
+            ds=ds,
+            z_new=z,
+            method=method,
+            conserve_column=conserve_column,
+        )
         return ds
     else:
         return ds
@@ -274,6 +280,7 @@ class AFGL1986Tropical(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         logger.debug(
@@ -283,6 +290,7 @@ class AFGL1986Tropical(Profile):
             identifier=Identifier.TROPICAL,
             z=z,
             interp_method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -296,6 +304,7 @@ class AFGL1986MidlatitudeSummer(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         logger.debug(
@@ -306,6 +315,7 @@ class AFGL1986MidlatitudeSummer(Profile):
             identifier=Identifier.MIDLATITUDE_SUMMER,
             z=z,
             interp_method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -319,6 +329,7 @@ class AFGL1986MidlatitudeWinter(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         logger.debug(
@@ -329,6 +340,7 @@ class AFGL1986MidlatitudeWinter(Profile):
             identifier=Identifier.MIDLATITUDE_WINTER,
             z=z,
             interp_method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -342,6 +354,7 @@ class AFGL1986SubarcticSummer(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         logger.debug(
@@ -352,6 +365,7 @@ class AFGL1986SubarcticSummer(Profile):
             identifier=Identifier.SUBARCTIC_SUMMER,
             z=z,
             interp_method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -365,6 +379,7 @@ class AFGL1986SubarcticWinter(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         logger.debug(
@@ -375,6 +390,7 @@ class AFGL1986SubarcticWinter(Profile):
             identifier=Identifier.SUBARCTIC_WINTER,
             z=z,
             interp_method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -388,6 +404,7 @@ class AFGL1986USStandard(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         logger.debug(
@@ -397,5 +414,6 @@ class AFGL1986USStandard(Profile):
             identifier=Identifier.US_STANDARD,
             z=z,
             interp_method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )

--- a/src/joseki/profiles/mipas_2007.py
+++ b/src/joseki/profiles/mipas_2007.py
@@ -285,6 +285,7 @@ def to_dataset(
     identifier: Identifier,
     z: t.Optional[pint.Quantity] = None,
     method: t.Optional[t.Mapping[str, str]] = None,
+    conserve_column: bool = False,
     **kwargs: t.Any,
 ) -> xr.Dataset:
     """Helper for `Profile.to_dataset` method"""
@@ -299,7 +300,12 @@ def to_dataset(
     # Interpolate to new vertical grid if necessary
     if z is not None:
         method = DEFAULT_METHOD if method is None else method
-        ds = interp(ds=ds, z_new=z, method=method)
+        ds = interp(
+            ds=ds,
+            z_new=z,
+            method=method,
+            conserve_column=conserve_column,
+        )
         return ds
     else:
         return ds
@@ -314,12 +320,14 @@ class MIPASMidlatitudeDay(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         return to_dataset(
             identifier=Identifier.MIDLATITUDE_DAY,
             z=z,
             method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -333,12 +341,14 @@ class MIPASMidlatitudeNight(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         return to_dataset(
             identifier=Identifier.MIDLATITUDE_NIGHT,
             z=z,
             method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -352,12 +362,14 @@ class MIPASPolarSummer(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         return to_dataset(
             identifier=Identifier.POLAR_SUMMER,
             z=z,
             method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -371,12 +383,14 @@ class MIPASPolarWinter(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         return to_dataset(
             identifier=Identifier.POLAR_WINTER,
             z=z,
             method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )
 
@@ -390,11 +404,13 @@ class MIPASTropical(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
         return to_dataset(
             identifier=Identifier.TROPICAL,
             z=z,
             method=interp_method,
+            conserve_column=conserve_column,
             **kwargs,
         )

--- a/src/joseki/profiles/schema.py
+++ b/src/joseki/profiles/schema.py
@@ -155,15 +155,6 @@ class Schema:
                     f"{ds[var].attrs['standard_name']}"
                 )
 
-        logger.debug("Checking that coordinates have the correct standard names")
-        for coord, (_, _, _, standard_name) in self.coords.items():
-            if ds[coord].attrs["standard_name"] != standard_name:
-                raise ValueError(  # pragma: no cover
-                    f"incorrect standard name for {coord}. Expected "
-                    f"{standard_name}, got "
-                    f"{ds[coord].attrs['standard_name']}"
-                )
-
         logger.debug(
             "Checking that all x_* data variables have the correct units and "
             "standard names"
@@ -189,7 +180,7 @@ class Schema:
             )
             vfs = volume_fraction_sum(ds)
             if np.any(vfs.m > 1):
-                raise ValueError(
+                raise ValueError(  # pragma: no cover
                     "The rescaling factors lead to a profile where the volume "
                     "fraction sum is larger than 1."
                 )

--- a/src/joseki/profiles/ussa_1976.py
+++ b/src/joseki/profiles/ussa_1976.py
@@ -35,14 +35,11 @@ class USSA1976(Profile):
         self,
         z: t.Optional[pint.Quantity] = None,
         interp_method: t.Optional[t.Mapping[str, str]] = None,
+        conserve_column: bool = False,
         **kwargs: t.Any,
     ) -> xr.Dataset:
-        # interpolation is not required
-        if interp_method is not None:
-            logger.warning(  # pragma: no cover
-                "interpolation is not required. The value of the "
-                "'interp_method' parameter will be ignored."
-            )
+        # Since the ussa_1976 model can be evaluated at any altitude, both
+        # interp_method and conserve_column are ignored.
 
         # kwargs are ignored
         if kwargs:

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -10,11 +10,21 @@ from joseki.units import to_quantity
 from joseki.units import ureg
 
 
+def test_column_number_density_integration():
+    """Same result is returned when profile is represented in cells or not."""
+    ds1 = joseki.make("mipas_2007-midlatitude_day")
+    ds2 = joseki.make("mipas_2007-midlatitude_day", represent_in_cells=True)
+    assert_approx_equal(
+        ds1.joseki.column_number_density["CO2"].m,
+        ds2.joseki.column_number_density["CO2"].m,
+        significant=5,
+    )
+
 @pytest.mark.parametrize(
     "identifier",
     ["ussa_1976", "afgl_1986-us_standard", "mipas_2007-midlatitude_day"]
 )
-def test_column_mass_density_in_cells(identifier: str):
+def test_column_mass_density(identifier: str):
     """Returns a dictionary."""
     ds = joseki.make(identifier)
     assert isinstance(ds.joseki.column_mass_density, dict)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,17 +2,18 @@
 import numpy as np
 import pytest
 import xarray as xr
+from numpy.testing import assert_approx_equal
 
 from joseki import unit_registry as ureg
 from joseki.core import make
 
 
-def test_make() -> None:
+def test_make():
     """Returns xr.Dataset."""
     assert isinstance(make(identifier="afgl_1986-tropical"), xr.Dataset)
 
 
-def test_make_represent_in_cells() -> None:
+def test_make_represent_in_cells():
     """Returned dataset has dimensions zbv and z and data variable z_bounds."""
     ds = make(
         identifier="afgl_1986-tropical",
@@ -23,7 +24,7 @@ def test_make_represent_in_cells() -> None:
     assert "z_bounds" in ds.data_vars
 
 
-def test_make_altitudes() -> None:
+def test_make_altitudes():
     """Assigns dataset' altitude values from file."""
     z = np.linspace(0, 120, 121) * ureg.km
     ds = make(identifier="afgl_1986-tropical", z=z)
@@ -41,7 +42,7 @@ def test_make_altitudes() -> None:
         "afgl_1986-us_standard",
     ],
 )
-def test_make_additional_molecules_false(identifier: str) -> None:
+def test_make_additional_molecules_false(identifier: str):
     """Additional molecules not included when additional_molecules=False."""
     ds = make(identifier=identifier, additional_molecules=False)
     assert len(ds.joseki.molecules) == 7
@@ -58,20 +59,70 @@ def test_make_additional_molecules_false(identifier: str) -> None:
         "afgl_1986-us_standard",
     ],
 )
-def test_make_additional_molecules_true(identifier: str) -> None:
+def test_make_additional_molecules_true(identifier: str):
     """Additional molecules are included when additional_molecules=True."""
     ds = make(identifier=identifier, additional_molecules=True)
     assert len(ds.joseki.molecules) == 28
 
 
-def test_make_ussa_1976() -> None:
+def test_make_ussa_1976():
     """Returns dataset."""
     ds = make(identifier="ussa_1976")
     assert isinstance(ds, xr.Dataset)
 
 
-def test_make_ussa_1976_z() -> None:
+def test_make_ussa_1976_z():
     """Returns dataset."""
     z = np.linspace(0.0, 100) * ureg.km
     ds = make(identifier="ussa_1976", z=z)
     assert isinstance(ds, xr.Dataset)
+
+
+def test_make_conserve_column_1():
+    """Column densities are conserved when conserve_column is True."""
+    ds0 = make(identifier="afgl_1986-us_standard")
+    ds1 = make(
+        identifier="afgl_1986-us_standard",
+        z=np.linspace(0, 100, 21) * ureg.km,  # different than default
+        conserve_column=True,
+    )
+
+    for m in ds0.joseki.molecules:
+        assert_approx_equal(
+            ds0.joseki.column_number_density[m].m,
+            ds1.joseki.column_number_density[m].m,
+            significant=6
+        )
+
+def test_make_conserve_column_2():
+    """Column densities are conserved when conserve_column is True."""
+    ds0 = make(identifier="afgl_1986-us_standard")
+    ds1 = make(
+        identifier="afgl_1986-us_standard",
+        represent_in_cells=True,
+        conserve_column=True,
+    )
+
+    for m in ds0.joseki.molecules:
+        assert_approx_equal(
+            ds0.joseki.column_number_density[m].m,
+            ds1.joseki.column_number_density[m].m,
+            significant=6
+        )
+
+def test_make_conserve_column_3():
+    """Column densities are conserved when conserve_column is True."""
+    ds0 = make(identifier="afgl_1986-us_standard")
+    ds1 = make(
+        identifier="afgl_1986-us_standard",
+        z=np.linspace(0, 100, 21) * ureg.km,  # different than default
+        represent_in_cells=True,
+        conserve_column=True,
+    )
+
+    for m in ds0.joseki.molecules:
+        assert_approx_equal(
+            ds0.joseki.column_number_density[m].m,
+            ds1.joseki.column_number_density[m].m,
+            significant=6
+        )


### PR DESCRIPTION
Specifying the altitude grid on which to represent a profile, or moving from a nodes-representation to a cells-representation is likely going to change the column number (and mass) densities. This pull request is to provide a way to ensure these column densities are conserved during these operations (interpolation and representation in cells).