### PR TITLE
Remove duplicate definition of `parts_per_billion` unit

### DIFF
--- a/src/joseki/units.py
+++ b/src/joseki/units.py
@@ -16,7 +16,7 @@ ureg = pint.get_application_registry()
 definitions = [
     # (mole) fraction
     "@alias ppm = parts_per_million = ppmv",
-    "parts_per_billion = parts_per_billion = 1e-9 = ppb = ppbv",
+    "parts_per_billion = 1e-9 = ppb = ppbv",
     "parts_per_trillion = 1e-12 = ppt = pptv",
 
     # column number density


### PR DESCRIPTION
Removed duplicate definition of parts_per_billion in the unit registry, which threw an infinite recursion exception when converting the units to something else.