### PR TITLE
Remove deprecation warning of the utcnow function

### DIFF
--- a/src/joseki/accessor.py
+++ b/src/joseki/accessor.py
@@ -423,7 +423,7 @@ class JosekiAccessor:  # pragma: no cover
             raise ValueError("Cannot rescale") from e
 
         # update history attribute
-        now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat()
         for m in factors.keys():
             ds.attrs["history"] += (
                 f"\n{now} - rescaled {m}'s mole fraction using a scaling "
@@ -471,7 +471,7 @@ class JosekiAccessor:  # pragma: no cover
         ds = self._obj
 
         # update history attribute
-        now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
+        now = datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat()
 
         ds.attrs["history"] += (
             f"\n{now} - dropped mole fraction data for molecules "

--- a/src/joseki/core.py
+++ b/src/joseki/core.py
@@ -162,7 +162,7 @@ def merge(
     )
 
     # update attributes
-    now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
+    now = datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat()
 
     institutions = set([ds.attrs["institution"] for ds in datasets])
     sources = set([ds.attrs["source"] for ds in datasets])

--- a/src/joseki/profiles/util.py
+++ b/src/joseki/profiles/util.py
@@ -16,7 +16,7 @@ def utcnow() -> str:
     Returns:
         ISO 8601 formatted UTC timestamp.
     """
-    return datetime.datetime.utcnow().replace(microsecond=0).isoformat()
+    return datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat()
 
 
 def number_density(p: pint.Quantity, t: pint.Quantity) -> pint.Quantity:


### PR DESCRIPTION
For my application I tend to create several atmospheric profiles in distributed batches, and my logs are flooded by this deprecation warning

```
  /[redacted]/lib/python3.12/site-packages/joseki/profiles/util.py:19: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    return datetime.datetime.utcnow().replace(microsecond=0).isoformat()
```

This simple patch fixes the issue by using the latest API as recommended.