### PR TITLE
Fix Sutherland's Law BETA

### DIFF
--- a/src/joseki/profiles/ussa_1976/constants.py
+++ b/src/joseki/profiles/ussa_1976/constants.py
@@ -90,7 +90,7 @@ T0 = 288.15
 S = 110.4
 """Sutherland constant in eq. 51 of :cite:`NASA1976USStandardAtmosphere` [K]."""
 
-BETA = 1.458e6
+BETA = 1.458e-6
 """:math:`\\beta` constant in eq. 51 of :cite:`NASA1976USStandardAtmosphere`
 [kg * m^-1 * s^-1 * K^-0.5]."""
 


### PR DESCRIPTION
The BETA constant for Sutherland's law in the 1976 US Standard Atmosphere is off by 12 orders of magnitude. The exponent is "-6", not "+6". This fixes the viscosity computation.